### PR TITLE
Revert "updates for new build system"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Change Log
 
-## [Unreleased]
-### Added
-- Updated the example to reflect the new build system
-- Updated documentation
-
 ## [1.0.0] - 2016-04-05
 ### Added
 - Initial Example

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,10 @@
 ################################################################################
 
 PARENT_SUBDIRS += vcpu_factory_msr_bitmap
+PARENT_SUBDIRS += vmcs_msr_bitmap
 
 ################################################################################
 # Common
 ################################################################################
 
-include %HYPER_ABS%/common/common_subdir.mk
+include ../common/common_subdir.mk

--- a/README.md
+++ b/README.md
@@ -1,50 +1,46 @@
-# Bareflank Hypervisor MSR Bitmap Example
+# Bareflank Hypervisor Example
 
 ## Description
 
-This example demonstrates how to extend the Bareflank hypervisor to use
-Intel's MSR Bitmaps to increase performance. For more information on how
-Bareflank extensions work, please see the following:
+This example demonstrates how to extend the Bareflank hypervisor to utilize the MSR bitmap feature of Intel virtualization. For more information on how Bareflank extensions work, please see the following:
 
 [API Documentation](http://bareflank.github.io/hypervisor/html/)
 
 ## Compilation / Usage
 
-To setup our extension, we can either clone the extension into the Bareflank
-root folder and run make, or we can use the configure script to create an
-out-of-tree build environment that has our extension setup for easy development.
-Note that using the later approach, we can have more than one build
-environment (the following assumes this is running on Linux).
+First, you must clone the repo into your existing Bareflank repo. To see instructions on how to setup Bareflank, please see the following:
+
+[Bareflank Hypervisor](https://github.com/Bareflank/hypervisor)
+
+At the moment, out-of-tree compilation is not supported.
 
 ```
-cd ~/
-git clone https://github.com/Bareflank/hypervisor.git
-git clone https://github.com/Bareflank/hypervisor_example_msr_bitmap.git
 cd ~/hypervisor
+git clone https://github.com/Bareflank/hypervisor_example_msr_bitmap
+```
 
-./tools/scripts/setup-<xxx>.sh --no-configure
-sudo reboot
+Once the example repo is cloned, you can now build the example. Bareflank automatically looks for the examples, or any folder that starts with "src_", and builds these folders along with Bareflank itself. 
 
-cd ~/
-mkdir build
-cd ~/build
-
-~/hypervisor/configure -m ~/hypervisor_example_msr_bitmap/bin/msr_bitmap.modules -e ~/hypervisor_example_msr_bitmap
-
+```
 make
-make unittest
 ```
 
-To test out our extended version of Bareflank, all we need to do is run the
-make shortcuts as usual:
+Finally, you can run the example. This can be done by running bfm manually, and providing the path to your custom modules list:
 
 ```
-make linux_load
-make quick
+pushd bfm/bin/native
+sudo LD_LIBRARY_PATH=. ./bfm load hypervisor_example_msr_bitmap/bin/msr_bitmap.modules
+sudo LD_LIBRARY_PATH=. ./bfm start
+sudo LD_LIBRARY_PATH=. ./bfm status
+sudo LD_LIBRARY_PATH=. ./bfm dump
+popd
+```
 
+or you can use the shortcuts:
+
+```
+make load MODULES=hypervisor_example_msr_bitmap/bin/msr_bitmap.modules
+make start
 make status
 make dump
-
-make stop
-make linux_unload
 ```

--- a/bin/msr_bitmap.modules
+++ b/bin/msr_bitmap.modules
@@ -6,20 +6,21 @@
 #
 # Note: The existing vcpu_factory module is commented out as we will be
 # providing our own.
-%BUILD_ABS%/sysroot/x86_64-elf/lib/libc++.so
-%BUILD_ABS%/makefiles/bfvmm/src/debug_ring/bin/cross/libdebug_ring.so
-%BUILD_ABS%/makefiles/bfvmm/src/entry/bin/cross/libentry.so
-%BUILD_ABS%/makefiles/bfvmm/src/exit_handler/bin/cross/libexit_handler.so
-%BUILD_ABS%/makefiles/bfvmm/src/intrinsics/bin/cross/libintrinsics.so
-%BUILD_ABS%/makefiles/bfvmm/src/memory_manager/bin/cross/libmemory_manager.so
-%BUILD_ABS%/makefiles/bfvmm/src/misc/bin/cross/libmisc.so
-%BUILD_ABS%/makefiles/bfvmm/src/serial/bin/cross/libserial.so
-%BUILD_ABS%/makefiles/bfvmm/src/vcpu/bin/cross/libvcpu.so
-#    %BUILD_ABS%/makefiles/bfvmm/src/vcpu_factory/bin/cross/libvcpu_factory.so
-%BUILD_ABS%/makefiles/bfvmm/src/vmcs/bin/cross/libvmcs.so
-%BUILD_ABS%/makefiles/bfvmm/src/vmxon/bin/cross/libvmxon.so
+../../../bfvmm/bin/cross/libmemory_manager.so
+../../../bfvmm/bin/cross/libentry.so
+../../../bfvmm/bin/cross/libserial.so
+../../../bfvmm/bin/cross/libdebug_ring.so
+../../../bfvmm/bin/cross/libintrinsics.so
+../../../bfvmm/bin/cross/libvmxon.so
+../../../bfvmm/bin/cross/libvmcs.so
+../../../bfvmm/bin/cross/libvcpu.so
+#../../../bfvmm/bin/cross/libvcpu_factory.so
+../../../bfvmm/bin/cross/libexit_handler.so
+../../../bfvmm/bin/cross/libmisc.so
+../../../bfvmm/bin/cross/libc++.so
 
 # Custom Modules
 #
 # Note: This is where we provide our own vcpu_factory.
-%BUILD_ABS%/makefiles/hypervisor_example_msr_bitmap/vcpu_factory_msr_bitmap/bin/cross/libvcpu_factory_msr_bitmap.so
+../../../hypervisor_example_msr_bitmap/bin/cross/libvcpu_factory_msr_bitmap.so
+../../../hypervisor_example_msr_bitmap/bin/cross/libvmcs_intel_x64_msr_bitmap.so

--- a/exit_handler_msr_bitmap/exit_handler_msr_bitmap.h
+++ b/exit_handler_msr_bitmap/exit_handler_msr_bitmap.h
@@ -19,9 +19,6 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#ifndef EXIT_HANDLER_MSR_BITMAP_H
-#define EXIT_HANDLER_MSR_BITMAP_H
-
 #include <exit_handler/exit_handler_intel_x64.h>
 
 class exit_handler_msr_bitmap : public exit_handler_intel_x64
@@ -46,5 +43,3 @@ public:
     virtual void handle_wrmsr()
     { unimplemented_handler(); }
 };
-
-#endif

--- a/vcpu_factory_msr_bitmap/Makefile
+++ b/vcpu_factory_msr_bitmap/Makefile
@@ -29,4 +29,4 @@ SUBDIRS += src
 # Common
 ################################################################################
 
-include %HYPER_ABS%/common/common_subdir.mk
+include ../../common/common_subdir.mk

--- a/vcpu_factory_msr_bitmap/src/Makefile
+++ b/vcpu_factory_msr_bitmap/src/Makefile
@@ -1,0 +1,87 @@
+#
+# Bareflank Hypervisor Examples
+#
+# Copyright (C) 2015 Assured Information Security, Inc.
+# Author: Rian Quinn        <quinnr@ainfosec.com>
+# Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+################################################################################
+# Target Information
+################################################################################
+
+TARGET_NAME:=vcpu_factory_msr_bitmap
+TARGET_TYPE:=lib
+TARGET_COMPILER:=cross
+
+################################################################################
+# Compiler Flags
+################################################################################
+
+CROSS_CCFLAGS+=
+CROSS_CXXFLAGS+=
+CROSS_ASMFLAGS+=
+CROSS_LDFLAGS+=
+CROSS_ARFLAGS+=
+CROSS_DEFINES+=
+
+################################################################################
+# Output
+################################################################################
+
+CROSS_OBJDIR:=.build
+CROSS_OUTDIR:=../../bin
+
+################################################################################
+# Sources
+################################################################################
+
+SOURCES+=vcpu_factory_msr_bitmap.cpp
+
+INCLUDE_PATHS+=./
+INCLUDE_PATHS+=../../
+INCLUDE_PATHS+=../../vmcs_msr_bitmap
+INCLUDE_PATHS+=../../../include/
+INCLUDE_PATHS+=../../../bfvmm/include/
+
+LIBS+=
+
+LIBRARY_PATHS+=
+
+################################################################################
+# Environment Specific
+################################################################################
+
+VMM_SOURCES+=
+VMM_INCLUDE_PATHS+=
+VMM_LIBS+=
+VMM_LIBRARY_PATHS+=
+
+WINDOWS_SOURCES+=
+WINDOWS_INCLUDE_PATHS+=
+WINDOWS_LIBS+=
+WINDOWS_LIBRARY_PATHS+=
+
+LINUX_SOURCES+=
+LINUX_INCLUDE_PATHS+=
+LINUX_LIBS+=
+LINUX_LIBRARY_PATHS+=
+
+################################################################################
+# Common
+################################################################################
+
+include ../../../common/common_target.mk

--- a/vcpu_factory_msr_bitmap/src/vcpu_factory_msr_bitmap.cpp
+++ b/vcpu_factory_msr_bitmap/src/vcpu_factory_msr_bitmap.cpp
@@ -21,17 +21,30 @@
 
 #include <vcpu/vcpu_factory.h>
 #include <vcpu/vcpu_intel_x64.h>
-#include <vmcs_msr_bitmap/vmcs_intel_x64_msr_bitmap.h>
+#include <vmcs_intel_x64_msr_bitmap.h>
 #include <exit_handler_msr_bitmap/exit_handler_msr_bitmap.h>
 
 std::shared_ptr<vcpu>
 vcpu_factory::make_vcpu(int64_t vcpuid)
 {
-    auto vmcs = std::make_shared<vmcs_intel_x64_msr_bitmap>();
+    // The vCPU Factory is used by the vCPU Manager to create vCPUs. This not
+    // only provides a hook for unit testing (the classic factory pattern), but
+    // also provides a clever place to hook in custom functionality above and
+    // beyond what bareflank provides by default.
+
+    // In this example, we are providing a custom exit handler that does not
+    // have any MSR emulation included.
     auto exit_handler = std::make_shared<exit_handler_msr_bitmap>();
 
-    // Return a vCPU with our custom objects instead of the defaults which
-    // are represented by the null pointers.
+    // Provide a custom VMCS that initializes the MSR bitmap
+    auto vmcs = std::make_shared<vmcs_intel_x64_msr_bitmap>();
+
+    // Now that we have our custom exit handler, we can provide it to the
+    // vCPU that bareflank provides. Note that you could create your own vCPU
+    // if you need to, but in general, the existing vCPU should work for most
+    // cases as it allows you to override each of the classes that are required.
+    // In all cases here, if nullptr is provided, the code under the hood will
+    // create the class for you using the defaults.
     return std::make_shared<vcpu_intel_x64>(vcpuid,
                                             nullptr,
                                             nullptr,

--- a/vmcs_msr_bitmap/Makefile
+++ b/vmcs_msr_bitmap/Makefile
@@ -23,7 +23,7 @@
 # Target Information
 ################################################################################
 
-TARGET_NAME:=vcpu_factory_msr_bitmap
+TARGET_NAME:=vmcs_intel_x64_msr_bitmap
 TARGET_TYPE:=lib
 TARGET_COMPILER:=cross
 
@@ -42,18 +42,20 @@ CROSS_DEFINES+=
 # Output
 ################################################################################
 
-CROSS_OBJDIR+=%BUILD_REL%/.build
-CROSS_OUTDIR+=%BUILD_REL%/../bin
+CROSS_OBJDIR:=.build
+CROSS_OUTDIR:=../bin
 
 ################################################################################
 # Sources
 ################################################################################
 
-SOURCES+=vcpu_factory_msr_bitmap.cpp
+SOURCES+=vmcs_intel_x64_msr_bitmap.cpp
+SOURCES+=bitmap.cpp
 
-INCLUDE_PATHS+=../../
-INCLUDE_PATHS+=%HYPER_ABS%/include/
-INCLUDE_PATHS+=%HYPER_ABS%/bfvmm/include/
+INCLUDE_PATHS+=./
+INCLUDE_PATHS+=../
+INCLUDE_PATHS+=../../include/
+INCLUDE_PATHS+=../../bfvmm/include/
 
 LIBS+=
 
@@ -82,4 +84,4 @@ LINUX_LIBRARY_PATHS+=
 # Common
 ################################################################################
 
-include %HYPER_ABS%/common/common_target.mk
+include ../../common/common_target.mk

--- a/vmcs_msr_bitmap/bitmap.cpp
+++ b/vmcs_msr_bitmap/bitmap.cpp
@@ -1,0 +1,79 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <bitmap.h>
+#include <memory_manager/memory_manager.h>
+
+bitmap::bitmap(uint32_t num_bits)
+{
+    m_length = num_bits >> 3;
+
+    if (num_bits & 7)
+        m_length++;
+
+    m_bitmap = std::make_unique<uint8_t[]>(m_length);
+
+    m_virt_addr = (uint64_t)m_bitmap.get();
+    m_phys_addr = (uint64_t)g_mm->virt_to_phys(m_bitmap.get());
+}
+
+bitmap::bitmap()
+{
+    // Default to a full page bitmap
+    uint32_t num_bits = 4096*8;
+    m_length = num_bits >> 3;
+
+    if (num_bits & 7)
+        m_length++;
+
+    m_bitmap = std::make_unique<uint8_t[]>(m_length);
+
+    m_virt_addr = (uint64_t)m_bitmap.get();
+    m_phys_addr = (uint64_t)g_mm->virt_to_phys(m_bitmap.get());
+}
+
+
+void bitmap::set_bit(uint32_t n) noexcept
+{
+    if ((n >> 3) > m_length)
+        return;
+
+    m_bitmap.get()[n >> 3] |= (1 << (n & 7));
+}
+
+void bitmap::clear_bit(uint32_t n) noexcept
+{
+    if ((n >> 3) > m_length)
+        return;
+
+    m_bitmap.get()[n >> 3] &= ~(1 << (n & 7));
+}
+
+bool bitmap::bit(uint32_t n) const noexcept
+{
+    if ((n >> 3) > m_length)
+        return false;
+
+    if (m_bitmap.get()[n >> 3] & (1 << (n & 7)))
+        return true;
+
+    return false;
+}

--- a/vmcs_msr_bitmap/bitmap.h
+++ b/vmcs_msr_bitmap/bitmap.h
@@ -1,0 +1,88 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef BITMAP_H
+#define BITMAP_H
+
+#include <stdint.h>
+#include <memory>
+
+class bitmap
+{
+public:
+
+    /// Default Constructor
+    ///
+    /// Constructs a bitmap of a page size
+    ///
+    bitmap();
+
+    /// Constructor
+    ///
+    /// @param num_bits size of the bitmap in bits
+    ///
+    bitmap(uint32_t num_bits);
+
+    /// Destructor
+    ///
+    virtual ~bitmap() {}
+
+    /// Virtual Address
+    ///
+    /// @return the virtual address of the beginning of the bitmap
+    ///
+    uint64_t virt_addr() const noexcept
+    { return m_virt_addr; }
+
+    /// Physical Address
+    ///
+    /// @return the virtual address of the beginning of the bitmap
+    ///
+    uint64_t phys_addr() const noexcept
+    { return m_phys_addr; }
+
+    /// Set Bit
+    ///
+    /// @param n nth bit to set in the bitmap
+    ///
+    void set_bit(uint32_t n) noexcept;
+
+    /// Reset Bit
+    ///
+    /// @param n nth bit to clear in the bitmap
+    ///
+    void clear_bit(uint32_t n) noexcept;
+
+    /// Get Bit
+    ///
+    /// @param n nth bit's status to return
+    /// @return true if the bit is set, false otherwise
+    ///
+    bool bit(uint32_t n) const noexcept;
+
+private:
+    uint32_t m_length;
+    uint64_t m_virt_addr;
+    uint64_t m_phys_addr;
+    std::unique_ptr<uint8_t[]> m_bitmap;
+};
+
+#endif

--- a/vmcs_msr_bitmap/vmcs_intel_x64_msr_bitmap.cpp
+++ b/vmcs_msr_bitmap/vmcs_intel_x64_msr_bitmap.cpp
@@ -1,0 +1,91 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <debug.h>
+#include <constants.h>
+#include <vmcs_intel_x64_msr_bitmap.h>
+#include <memory_manager/memory_manager.h>
+
+vmcs_intel_x64_msr_bitmap::vmcs_intel_x64_msr_bitmap() :
+    m_msr_bitmap()
+{
+    if (!m_intrinsics)
+        m_intrinsics = std::make_shared<intrinsics_intel_x64>();
+}
+
+void
+vmcs_intel_x64_msr_bitmap::write_64bit_control_state(const std::shared_ptr<vmcs_intel_x64_state> &state)
+{
+    (void) state;
+
+    // unused: VMCS_ADDRESS_OF_IO_BITMAP_A_FULL
+    // unused: VMCS_ADDRESS_OF_IO_BITMAP_B_FULL
+    vmwrite(VMCS_ADDRESS_OF_MSR_BITMAPS_FULL, (uint64_t)m_msr_bitmap.phys_addr());
+    // unused: VMCS_VM_EXIT_MSR_STORE_ADDRESS_FULL
+    // unused: VMCS_VM_EXIT_MSR_LOAD_ADDRESS_FULL
+    // unused: VMCS_VM_ENTRY_MSR_LOAD_ADDRESS_FULL
+    // unused: VMCS_EXECUTIVE_VMCS_POINTER_FULL
+    // unused: VMCS_TSC_OFFSET_FULL
+    // unused: VMCS_VIRTUAL_APIC_ADDRESS_FULL
+    // unused: VMCS_APIC_ACCESS_ADDRESS_FULL
+    // unused: VMCS_POSTED_INTERRUPT_DESCRIPTOR_ADDRESS_FULL
+    // unused: VMCS_VM_FUNCTION_CONTROLS_FULL
+    // unused: VMCS_EPT_POINTER_FULL
+    // unused: VMCS_EOI_EXIT_BITMAP_0_FULL
+    // unused: VMCS_EOI_EXIT_BITMAP_1_FULL
+    // unused: VMCS_EOI_EXIT_BITMAP_2_FULL
+    // unused: VMCS_EOI_EXIT_BITMAP_3_FULL
+    // unused: VMCS_EPTP_LIST_ADDRESS_FULL
+    // unused: VMCS_VMREAD_BITMAP_ADDRESS_FULL
+    // unused: VMCS_VMWRITE_BITMAP_ADDRESS_FULL
+    // unused: VMCS_VIRTUALIZATION_EXCEPTION_INFORMATION_ADDRESS_FULL
+    // unused: VMCS_XSS_EXITING_BITMAP_FULL
+}
+
+void
+vmcs_intel_x64_msr_bitmap::primary_processor_based_vm_execution_controls()
+{
+    auto controls = vmread(VMCS_PRIMARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS);
+
+    // controls |= VM_EXEC_P_PROC_BASED_INTERRUPT_WINDOW_EXITING;
+    // controls |= VM_EXEC_P_PROC_BASED_USE_TSC_OFFSETTING;
+    // controls |= VM_EXEC_P_PROC_BASED_HLT_EXITING;
+    // controls |= VM_EXEC_P_PROC_BASED_INVLPG_EXITING;
+    // controls |= VM_EXEC_P_PROC_BASED_MWAIT_EXITING;
+    // controls |= VM_EXEC_P_PROC_BASED_RDPMC_EXITING;
+    // controls |= VM_EXEC_P_PROC_BASED_RDTSC_EXITING;
+    // controls |= VM_EXEC_P_PROC_BASED_CR3_LOAD_EXITING;
+    // controls |= VM_EXEC_P_PROC_BASED_CR3_STORE_EXITING;
+    // controls |= VM_EXEC_P_PROC_BASED_CR8_LOAD_EXITING;
+    // controls |= VM_EXEC_P_PROC_BASED_CR8_STORE_EXITING;
+    // controls |= VM_EXEC_P_PROC_BASED_USE_TPR_SHADOW;
+    // controls |= VM_EXEC_P_PROC_BASED_NMI_WINDOW_EXITING;
+    // controls |= VM_EXEC_P_PROC_BASED_MOV_DR_EXITING;
+    // controls |= VM_EXEC_P_PROC_BASED_UNCONDITIONAL_IO_EXITING;
+    // controls |= VM_EXEC_P_PROC_BASED_USE_IO_BITMAPS;
+    // controls |= VM_EXEC_P_PROC_BASED_MONITOR_TRAP_FLAG;
+    controls |= VM_EXEC_P_PROC_BASED_USE_MSR_BITMAPS;
+    // controls |= VM_EXEC_P_PROC_BASED_MONITOR_EXITING;
+    // controls |= VM_EXEC_P_PROC_BASED_PAUSE_EXITING;
+    // controls |= VM_EXEC_P_PROC_BASED_ACTIVATE_SECONDARY_CONTROLS;
+
+    vmwrite(VMCS_PRIMARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS, controls);
+}

--- a/vmcs_msr_bitmap/vmcs_intel_x64_msr_bitmap.h
+++ b/vmcs_msr_bitmap/vmcs_intel_x64_msr_bitmap.h
@@ -23,7 +23,7 @@
 #define VMCS_INTEL_X64_MSR_BITMAP_H
 
 #include <vmcs/vmcs_intel_x64.h>
-#include <memory_manager/memory_manager.h>
+#include <bitmap.h>
 
 class vmcs_intel_x64_msr_bitmap : public vmcs_intel_x64
 {
@@ -31,46 +31,18 @@ public:
 
     /// Default Constructor
     ///
-    vmcs_intel_x64_msr_bitmap()
-    {
-        // Allocate the MSR bitmap. Note that we use the memory manager to
-        // do this so that we can get aligned memory, as C++ does not have
-        // aligned memory allocation
-        m_msr_bitmap = std::unique_ptr<char[]>((char *)g_mm->malloc_aligned(4096, 4096));
-    }
+    vmcs_intel_x64_msr_bitmap();
 
     /// Destructor
     ///
     virtual ~vmcs_intel_x64_msr_bitmap() {}
 
 protected:
-
-    void
-    write_64bit_control_state(const std::shared_ptr<vmcs_intel_x64_state> &state) override
-    {
-        // Tell the VMCS were the MSR bitmap is located
-        vmwrite(VMCS_ADDRESS_OF_MSR_BITMAPS_FULL, (uint64_t)g_mm->virt_to_phys(m_msr_bitmap.get()));
-
-        bfdebug << "enabling msr bitmaps" << bfendl;
-
-        // Call the base class to enable any other features that are needed.
-        vmcs_intel_x64::write_64bit_control_state(state);
-    }
-
-    void
-    primary_processor_based_vm_execution_controls() override
-    {
-        // Enable the MSR bitmaps
-        auto controls = vmread(VMCS_PRIMARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS);
-        controls |= VM_EXEC_P_PROC_BASED_USE_MSR_BITMAPS;
-        vmwrite(VMCS_PRIMARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS, controls);
-
-        // Call the base class to enable any other features that are needed.
-        vmcs_intel_x64::primary_processor_based_vm_execution_controls();
-    }
+	virtual void write_64bit_control_state(const std::shared_ptr<vmcs_intel_x64_state> &state);
+	virtual void primary_processor_based_vm_execution_controls();
 
 private:
-    std::unique_ptr<char[]> m_msr_bitmap;
+    bitmap m_msr_bitmap;
 };
 
 #endif


### PR DESCRIPTION
Reverts Bareflank/hypervisor_example_msr_bitmap#1

Commit message is misleading, and removes functionality that make the example somewhat useful as a starting point for other work.
